### PR TITLE
Teezily/web base Ubuntu 16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = teezily/web-base
-VERSION = 0.9.21
+VERSION = 0.9.22
 
 .PHONY: all build_all \
 	build_customizable \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage:0.9.19
 MAINTAINER Phusion <info@phusion.nl>
 
 # Set the locale

--- a/image/enable_repos.sh
+++ b/image/enable_repos.sh
@@ -5,8 +5,6 @@ set -x
 
 ## Brightbox Ruby 1.9.3, 2.0, 2.1 and 2.2
 echo deb http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu trusty main > /etc/apt/sources.list.d/brightbox.list
-echo deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main > /etc/apt/sources.list.d/nginx-stable.list
-
 
 # The recv-keys part takes a bit of time, so it's faster to receive multiple keys at once.
 #

--- a/image/nginx-passenger.sh
+++ b/image/nginx-passenger.sh
@@ -4,7 +4,7 @@ source /pd_build/buildconfig
 source /etc/environment
 set -x
 
-apt-get install -y nginx-extras
+minimal_apt_get_install nginx-extras
 
 cp /pd_build/config/nginx.conf /etc/nginx/nginx.conf
 mkdir -p /etc/nginx/main.d


### PR DESCRIPTION
A Teezily project had encounter some trouble with OpenSSL, and I needed to try with a newer version of Ubuntu.

I based this new Dockerfile on phusion/baseimage:0.9.19 to gain access to Ubuntu 16.04

I open this PR to discuss the subject and question:
- How do you want to handle this evolution ? Just let a branch open on this repo ? Merge it on teezily/web-base (our main branch here) ?

Anyway, give me a go and at least I will push the image on docker hub, named: "teezily/web-base-ruby23:0.9.22"